### PR TITLE
feat: add ignore-content option

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,7 @@ Instruction
 #### File Selection Options
 - `--include <patterns>`: List of include patterns (comma-separated)
 - `-i, --ignore <patterns>`: Additional ignore patterns (comma-separated)
+- `--ignore-content <patterns>`: Patterns to include files but skip their content (comma-separated)
 - `--no-gitignore`: Disable .gitignore file usage
 - `--no-default-patterns`: Disable default patterns
 
@@ -606,6 +607,9 @@ repomix --compress
 
 # Process specific files
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Ignore file contents for matching patterns
+repomix --ignore-content "docs/**,LICENSE"
 
 # Remote repository with branch
 repomix --remote https://github.com/user/repo/tree/main
@@ -959,6 +963,7 @@ Here's an explanation of the configuration options:
 | `output.git.includeLogs`        | Whether to include git logs in the output (includes commit history with dates, messages, and file paths)                   | `false`                |
 | `output.git.includeLogsCount`   | Number of git log commits to include                                                                                         | `50`                   |
 | `include`                        | Patterns of files to include (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax))  | `[]`                   |
+| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
 | `ignore.useGitignore`            | Whether to use patterns from the project's `.gitignore` file                                                                 | `true`                 |
 | `ignore.useDefaultPatterns`      | Whether to use default ignore patterns                                                                                       | `true`                 |
 | `ignore.customPatterns`          | Additional patterns to ignore (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
@@ -1004,6 +1009,7 @@ Example configuration:
     }
   },
   "include": ["**/*"],
+  "ignoreContent": ["docs/**","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -157,6 +157,9 @@ export const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
   if (options.ignore) {
     cliConfig.ignore = { customPatterns: splitPatterns(options.ignore) };
   }
+  if (options.ignoreContent) {
+    cliConfig.ignoreContent = splitPatterns(options.ignoreContent);
+  }
   // Only apply gitignore setting if explicitly set to false
   if (options.gitignore === false) {
     cliConfig.ignore = { ...cliConfig.ignore, useGitignore: options.gitignore };

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -105,6 +105,7 @@ export const run = async () => {
       .optionsGroup('File Selection Options')
       .option('--include <patterns>', 'list of include patterns (comma-separated)')
       .option('-i, --ignore <patterns>', 'additional ignore patterns (comma-separated)')
+      .option('--ignore-content <patterns>', 'patterns to skip file content (comma-separated)')
       .option('--no-gitignore', 'disable .gitignore file usage')
       .option('--no-default-patterns', 'disable default patterns')
       // Remote Repository Options

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -30,6 +30,7 @@ export interface CliOptions extends OptionValues {
   // Filter Options
   include?: string;
   ignore?: string;
+  ignoreContent?: string;
   gitignore?: boolean;
   defaultPatterns?: boolean;
   stdin?: boolean;

--- a/src/config/configLoad.ts
+++ b/src/config/configLoad.ts
@@ -130,6 +130,11 @@ export const mergeConfigs = (
       ...cliConfig.output,
     },
     include: [...(baseConfig.include || []), ...(fileConfig.include || []), ...(cliConfig.include || [])],
+    ignoreContent: [
+      ...(baseConfig.ignoreContent || []),
+      ...(fileConfig.ignoreContent || []),
+      ...(cliConfig.ignoreContent || []),
+    ],
     ignore: {
       ...baseConfig.ignore,
       ...fileConfig.ignore,

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -51,6 +51,7 @@ export const repomixConfigBaseSchema = z.object({
     })
     .optional(),
   include: z.array(z.string()).optional(),
+  ignoreContent: z.array(z.string()).optional(),
   ignore: z
     .object({
       useGitignore: z.boolean().optional(),
@@ -112,6 +113,7 @@ export const repomixConfigDefaultSchema = z.object({
     })
     .default({}),
   include: z.array(z.string()).default([]),
+  ignoreContent: z.array(z.string()).default([]),
   ignore: z
     .object({
       useGitignore: z.boolean().default(true),

--- a/src/core/file/fileCollect.ts
+++ b/src/core/file/fileCollect.ts
@@ -1,3 +1,4 @@
+import { minimatch } from 'minimatch';
 import pc from 'picocolors';
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
@@ -34,6 +35,7 @@ export const collectFiles = async (
         filePath,
         rootDir,
         maxFileSize: config.input.maxFileSize,
+        skipContent: config.ignoreContent.some((pattern) => minimatch(filePath, pattern)),
       }) satisfies FileCollectTask,
   );
 

--- a/src/core/file/fileProcess.ts
+++ b/src/core/file/fileProcess.ts
@@ -21,13 +21,14 @@ export const processFiles = async (
     getFileManipulator,
   },
 ): Promise<ProcessedFile[]> => {
+  const filesToProcess = rawFiles.filter((file) => file.content !== undefined);
   const taskRunner = deps.initTaskRunner<FileProcessTask, ProcessedFile>({
-    numOfTasks: rawFiles.length,
+    numOfTasks: filesToProcess.length,
     workerPath: new URL('./workers/fileProcessWorker.js', import.meta.url).href,
     // High memory usage and leak risk
     runtime: 'child_process',
   });
-  const tasks = rawFiles.map(
+  const tasks = filesToProcess.map(
     (rawFile, _index) =>
       ({
         rawFile,
@@ -37,7 +38,7 @@ export const processFiles = async (
 
   try {
     const startTime = process.hrtime.bigint();
-    logger.trace(`Starting file processing for ${rawFiles.length} files using worker pool`);
+    logger.trace(`Starting file processing for ${filesToProcess.length} files using worker pool`);
 
     let completedTasks = 0;
     const totalTasks = tasks.length;

--- a/src/core/file/fileProcessContent.ts
+++ b/src/core/file/fileProcessContent.ts
@@ -20,6 +20,9 @@ import { truncateBase64Content } from './truncateBase64.js';
  */
 export const processContent = async (rawFile: RawFile, config: RepomixConfigMerged): Promise<string> => {
   const processStartAt = process.hrtime.bigint();
+  if (rawFile.content === undefined) {
+    throw new Error(`No content to process for ${rawFile.path}`);
+  }
   let processedContent = rawFile.content;
   const manipulator = getFileManipulator(rawFile.path);
 

--- a/src/core/file/fileTypes.ts
+++ b/src/core/file/fileTypes.ts
@@ -1,6 +1,6 @@
 export interface RawFile {
   path: string;
-  content: string;
+  content?: string;
 }
 
 export interface ProcessedFile {

--- a/src/core/file/workers/fileCollectWorker.ts
+++ b/src/core/file/workers/fileCollectWorker.ts
@@ -11,6 +11,7 @@ export interface FileCollectTask {
   filePath: string;
   rootDir: string;
   maxFileSize: number;
+  skipContent?: boolean;
 }
 
 export interface SkippedFileInfo {
@@ -23,8 +24,21 @@ export interface FileCollectResult {
   skippedFile?: SkippedFileInfo;
 }
 
-export default async ({ filePath, rootDir, maxFileSize }: FileCollectTask): Promise<FileCollectResult> => {
+export default async ({
+  filePath,
+  rootDir,
+  maxFileSize,
+  skipContent = false,
+}: FileCollectTask): Promise<FileCollectResult> => {
   const fullPath = path.resolve(rootDir, filePath);
+  if (skipContent) {
+    return {
+      rawFile: {
+        path: filePath,
+      },
+    };
+  }
+
   const result = await readRawFile(fullPath, maxFileSize);
 
   if (result.content !== null) {

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -111,9 +111,10 @@ export const pack = async (
     );
 
   // Process files (remove comments, etc.)
+  const rawFilesForProcessing = safeRawFiles.filter((file) => file.content !== undefined);
   progressCallback('Processing files...');
   const processedFiles = await withMemoryLogging('Process Files', () =>
-    deps.processFiles(safeRawFiles, config, progressCallback),
+    deps.processFiles(rawFilesForProcessing, config, progressCallback),
   );
 
   progressCallback('Generating output...');

--- a/src/core/security/securityCheck.ts
+++ b/src/core/security/securityCheck.ts
@@ -14,7 +14,7 @@ export interface SuspiciousFileResult {
 }
 
 export const runSecurityCheck = async (
-  rawFiles: RawFile[],
+  rawFiles: Array<RawFile & { content: string }>,
   progressCallback: RepomixProgressCallback = () => {},
   gitDiffResult?: GitDiffResult,
   gitLogResult?: GitLogResult,

--- a/src/core/security/validateFileSafety.ts
+++ b/src/core/security/validateFileSafety.ts
@@ -27,7 +27,10 @@ export const validateFileSafety = async (
 
   if (config.security.enableSecurityCheck) {
     progressCallback('Running security check...');
-    const allResults = await deps.runSecurityCheck(rawFiles, progressCallback, gitDiffResult, gitLogResult);
+    const filesWithContent = rawFiles.filter(
+      (file): file is RawFile & { content: string } => file.content !== undefined,
+    );
+    const allResults = await deps.runSecurityCheck(filesWithContent, progressCallback, gitDiffResult, gitLogResult);
 
     // Separate Git diff and Git log results from regular file results
     suspiciousFilesResults = allResults.filter((result) => result.type === 'file');

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -162,6 +162,22 @@ describe('defaultAction', () => {
     );
   });
 
+  it('should handle ignore-content patterns', async () => {
+    const options: CliOptions = {
+      ignoreContent: 'docs/**,LICENSE',
+    };
+
+    await runDefaultAction(['.'], process.cwd(), options);
+
+    expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+      process.cwd(),
+      expect.anything(),
+      expect.objectContaining({
+        ignoreContent: ['docs/**', 'LICENSE'],
+      }),
+    );
+  });
+
   it('should handle custom output style', async () => {
     const options: CliOptions = {
       style: 'xml',

--- a/tests/config/configSchema.test.ts
+++ b/tests/config/configSchema.test.ts
@@ -128,6 +128,7 @@ describe('configSchema', () => {
           useDefaultPatterns: true,
           customPatterns: [],
         },
+        ignoreContent: [],
         security: {
           enableSecurityCheck: true,
         },
@@ -226,6 +227,7 @@ describe('configSchema', () => {
           useDefaultPatterns: true,
           customPatterns: ['*.log'],
         },
+        ignoreContent: [],
         security: {
           enableSecurityCheck: true,
         },

--- a/tests/core/file/fileCollect.test.ts
+++ b/tests/core/file/fileCollect.test.ts
@@ -82,6 +82,27 @@ describe('fileCollect', () => {
     });
   });
 
+  it('should skip file content when matching ignoreContent patterns', async () => {
+    const mockFilePaths = ['docs/readme.md', 'src/index.ts'];
+    const mockRootDir = '/root';
+    const mockConfig = createMockConfig({ ignoreContent: ['docs/**'] });
+
+    vi.mocked(isBinary).mockReturnValue(false);
+    vi.mocked(fs.readFile).mockResolvedValue(Buffer.from('file content'));
+    vi.mocked(jschardet.detect).mockReturnValue({ encoding: 'utf-8', confidence: 0.99 });
+    vi.mocked(iconv.decode).mockReturnValue('decoded content');
+
+    const result = await collectFiles(mockFilePaths, mockRootDir, mockConfig, () => {}, {
+      initTaskRunner: mockInitTaskRunner,
+    });
+
+    expect(result).toEqual({
+      rawFiles: [{ path: 'docs/readme.md' }, { path: 'src/index.ts', content: 'decoded content' }],
+      skippedFiles: [],
+    });
+    expect(fs.readFile).toHaveBeenCalledTimes(1);
+  });
+
   it('should skip binary files', async () => {
     const mockFilePaths = ['binary.bin', 'text.txt'];
     const mockRootDir = '/root';

--- a/tests/core/security/securityCheck.test.ts
+++ b/tests/core/security/securityCheck.test.ts
@@ -27,7 +27,7 @@ vi.mock('../../../src/shared/processConcurrency', () => ({
   })),
 }));
 
-const mockFiles: RawFile[] = [
+const mockFiles: Array<RawFile & { content: string }> = [
   {
     path: 'test1.js',
     // secretlint-disable

--- a/tests/testing/testUtils.ts
+++ b/tests/testing/testUtils.ts
@@ -32,6 +32,7 @@ export const createMockConfig = (config: DeepPartial<RepomixConfigMerged> = {}):
       ...config.ignore,
       customPatterns: [...(defaultConfig.ignore.customPatterns || []), ...(config.ignore?.customPatterns || [])],
     },
+    ignoreContent: [...(defaultConfig.ignoreContent || []), ...(config.ignoreContent || [])],
     include: [...(defaultConfig.include || []), ...(config.include || [])],
     security: {
       ...defaultConfig.security,

--- a/website/client/src/de/guide/command-line-options.md
+++ b/website/client/src/de/guide/command-line-options.md
@@ -35,6 +35,7 @@
 ## Dateiauswahloptionen
 - `--include <patterns>`: Liste der Einschlussmuster (kommagetrennt)
 - `-i, --ignore <patterns>`: Zusätzliche Ignoriermuster (kommagetrennt)
+- `--ignore-content <patterns>`: Skip file content for matched patterns (comma-separated)
 - `--no-gitignore`: .gitignore-Datei-Nutzung deaktivieren
 - `--no-default-patterns`: Standardmuster deaktivieren
 
@@ -74,6 +75,9 @@ repomix --compress
 
 # Spezifische Dateien verarbeiten
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Ignore file contents for matching patterns
+repomix --ignore-content "docs/**,LICENSE"
 
 # Remote-Repository mit Branch
 repomix --remote https://github.com/user/repo/tree/main

--- a/website/client/src/de/guide/configuration.md
+++ b/website/client/src/de/guide/configuration.md
@@ -42,6 +42,7 @@ repomix --init --global
 | `output.git.includeLogs`         | Ob Git-Logs in der Ausgabe enthalten sein sollen. Zeigt Commit-Historie mit Daten, Nachrichten und Dateipfaden an       | `false`                |
 | `output.git.includeLogsCount`    | Anzahl der Git-Log-Commits, die in die Ausgabe einbezogen werden sollen                                                   | `50`                   |
 | `include`                        | Zu einschließende Dateimuster (verwendet [glob-Muster](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
+| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
 | `ignore.useGitignore`            | Ob Muster aus der `.gitignore`-Datei des Projekts verwendet werden sollen                                                 | `true`                 |
 | `ignore.useDefaultPatterns`      | Ob Standard-Ignorier-Muster (node_modules, .git etc.) verwendet werden sollen                                             | `true`                 |
 | `ignore.customPatterns`          | Zusätzliche Ignorier-Muster (verwendet [glob-Muster](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
@@ -105,6 +106,7 @@ Hier ist ein Beispiel einer vollständigen Konfigurationsdatei (`repomix.config.
     }
   },
   "include": ["**/*"],
+  "ignoreContent": ["docs/**","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,

--- a/website/client/src/en/guide/command-line-options.md
+++ b/website/client/src/en/guide/command-line-options.md
@@ -35,6 +35,7 @@
 ## File Selection Options
 - `--include <patterns>`: List of include patterns (comma-separated)
 - `-i, --ignore <patterns>`: Additional ignore patterns (comma-separated)
+- `--ignore-content <patterns>`: Skip file content for matched patterns (comma-separated)
 - `--no-gitignore`: Disable .gitignore file usage
 - `--no-default-patterns`: Disable default patterns
 
@@ -72,6 +73,9 @@ repomix --compress
 
 # Process specific files
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Ignore file contents for matching patterns
+repomix --ignore-content "docs/**,LICENSE"
 
 # Remote repository with branch
 repomix --remote https://github.com/user/repo/tree/main

--- a/website/client/src/en/guide/configuration.md
+++ b/website/client/src/en/guide/configuration.md
@@ -42,6 +42,7 @@ repomix --init --global
 | `output.git.includeLogs`         | Whether to include git logs in the output. Shows commit history with dates, messages, and file paths                        | `false`                |
 | `output.git.includeLogsCount`    | Number of git log commits to include in the output                                                                          | `50`                   |
 | `include`                        | Patterns of files to include using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)    | `[]`                   |
+| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
 | `ignore.useGitignore`            | Whether to use patterns from the project's `.gitignore` file                                                                 | `true`                 |
 | `ignore.useDefaultPatterns`      | Whether to use default ignore patterns (node_modules, .git, etc.)                                                           | `true`                 |
 | `ignore.customPatterns`          | Additional patterns to ignore using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)   | `[]`                   |
@@ -105,6 +106,7 @@ Here's an example of a complete configuration file (`repomix.config.json`):
     }
   },
   "include": ["**/*"],
+  "ignoreContent": ["docs/**","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,

--- a/website/client/src/es/guide/command-line-options.md
+++ b/website/client/src/es/guide/command-line-options.md
@@ -35,6 +35,7 @@
 ## Opciones de selección de archivos
 - `--include <patterns>`: Lista de patrones de inclusión (separados por comas)
 - `-i, --ignore <patterns>`: Patrones de ignorar adicionales (separados por comas)
+- `--ignore-content <patterns>`: Skip file content for matched patterns (comma-separated)
 - `--no-gitignore`: Deshabilitar uso de archivo .gitignore
 - `--no-default-patterns`: Deshabilitar patrones por defecto
 
@@ -74,6 +75,9 @@ repomix --compress
 
 # Procesar archivos específicos
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Ignore file contents for matching patterns
+repomix --ignore-content "docs/**,LICENSE"
 
 # Repositorio remoto con rama
 repomix --remote https://github.com/user/repo/tree/main

--- a/website/client/src/es/guide/configuration.md
+++ b/website/client/src/es/guide/configuration.md
@@ -42,6 +42,7 @@ repomix --init --global
 | `output.git.includeLogs`         | Indica si se deben incluir los logs de git en la salida. Muestra el historial de commits con fechas, mensajes y rutas de archivos | `false`                |
 | `output.git.includeLogsCount`    | Número de commits de log de git a incluir en la salida                                                                          | `50`                   |
 | `include`                        | Patrones de archivos a incluir usando [patrones glob](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax) | `[]`                   |
+| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
 | `ignore.useGitignore`            | Indica si se deben usar los patrones del archivo `.gitignore` del proyecto                                                  | `true`                 |
 | `ignore.useDefaultPatterns`      | Indica si se deben usar los patrones de ignorar predeterminados (node_modules, .git, etc.)                                | `true`                 |
 | `ignore.customPatterns`          | Patrones adicionales para ignorar usando [patrones glob](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax) | `[]`                   |
@@ -105,6 +106,7 @@ Aquí hay un ejemplo de un archivo de configuración completo (`repomix.config.j
     }
   },
   "include": ["**/*"],
+  "ignoreContent": ["docs/**","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,

--- a/website/client/src/fr/guide/command-line-options.md
+++ b/website/client/src/fr/guide/command-line-options.md
@@ -35,6 +35,7 @@
 ## Options de sélection de fichiers
 - `--include <patterns>`: Liste des motifs d'inclusion (séparés par des virgules)
 - `-i, --ignore <patterns>`: Motifs d'ignorance supplémentaires (séparés par des virgules)
+- `--ignore-content <patterns>`: Skip file content for matched patterns (comma-separated)
 - `--no-gitignore`: Désactiver l'utilisation du fichier .gitignore
 - `--no-default-patterns`: Désactiver les motifs par défaut
 
@@ -74,6 +75,9 @@ repomix --compress
 
 # Traiter des fichiers spécifiques
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Ignore file contents for matching patterns
+repomix --ignore-content "docs/**,LICENSE"
 
 # Dépôt distant avec branche
 repomix --remote https://github.com/user/repo/tree/main

--- a/website/client/src/fr/guide/configuration.md
+++ b/website/client/src/fr/guide/configuration.md
@@ -42,6 +42,7 @@ repomix --init --global
 | `output.git.includeLogs`         | Indique s'il faut inclure les journaux git dans la sortie. Montre l'historique des commits avec les dates, les messages et les chemins de fichiers | `false`                |
 | `output.git.includeLogsCount`    | Nombre de commits de journaux git récents à inclure dans la sortie                                                                          | `50`                   |
 | `include`                        | Motifs des fichiers à inclure en utilisant les [motifs glob](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax) | `[]`                   |
+| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
 | `ignore.useGitignore`            | Indique s'il faut utiliser les motifs du fichier `.gitignore` du projet                                                      | `true`                 |
 | `ignore.useDefaultPatterns`      | Indique s'il faut utiliser les motifs d'ignorance par défaut (node_modules, .git, etc.)                                    | `true`                 |
 | `ignore.customPatterns`          | Motifs supplémentaires à ignorer en utilisant les [motifs glob](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax) | `[]`                   |
@@ -105,6 +106,7 @@ Voici un exemple de fichier de configuration complet (`repomix.config.json`) :
     }
   },
   "include": ["**/*"],
+  "ignoreContent": ["docs/**","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,

--- a/website/client/src/hi/guide/command-line-options.md
+++ b/website/client/src/hi/guide/command-line-options.md
@@ -35,6 +35,7 @@
 ## फ़ाइल चयन विकल्प
 - `--include <patterns>`: शामिल पैटर्न की सूची (कॉमा-अलग)
 - `-i, --ignore <patterns>`: अतिरिक्त अनदेखा पैटर्न (कॉमा-अलग)
+- `--ignore-content <patterns>`: Skip file content for matched patterns (comma-separated)
 - `--no-gitignore`: .gitignore फ़ाइल उपयोग अक्षम करें
 - `--no-default-patterns`: डिफ़ॉल्ट पैटर्न अक्षम करें
 
@@ -74,6 +75,9 @@ repomix --compress
 
 # विशिष्ट फ़ाइलों को प्रोसेस करना
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Ignore file contents for matching patterns
+repomix --ignore-content "docs/**,LICENSE"
 
 # ब्रांच के साथ रिमोट रिपॉजिटरी
 repomix --remote https://github.com/user/repo/tree/main

--- a/website/client/src/hi/guide/configuration.md
+++ b/website/client/src/hi/guide/configuration.md
@@ -42,6 +42,7 @@ repomix --init --global
 | `output.git.includeLogs`         | आउटपुट में Git logs शामिल करना है या नहीं। कमिट तारीखों, संदेशों और फ़ाइल पथों को दिखाता है                               | `false`                |
 | `output.git.includeLogsCount`    | आउटपुट में शामिल करने के लिए git log कमिट की संख्या                                                                     | `50`                   |
 | `include`                        | शामिल करने के लिए फ़ाइल पैटर्न [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax) का उपयोग करके | `[]`                   |
+| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
 | `ignore.useGitignore`            | प्रोजेक्ट की `.gitignore` फ़ाइल के पैटर्न का उपयोग करना है या नहीं                                                         | `true`                 |
 | `ignore.useDefaultPatterns`      | डिफ़ॉल्ट ignore पैटर्न (node_modules, .git, आदि) का उपयोग करना है या नहीं                                               | `true`                 |
 | `ignore.customPatterns`          | अतिरिक्त ignore पैटर्न [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax) का उपयोग करके | `[]`                   |
@@ -105,6 +106,7 @@ repomix --init --global
     }
   },
   "include": ["**/*"],
+  "ignoreContent": ["docs/**","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,

--- a/website/client/src/id/guide/command-line-options.md
+++ b/website/client/src/id/guide/command-line-options.md
@@ -35,6 +35,7 @@
 ## Opsi Seleksi File
 - `--include <patterns>`: Daftar pola penyertaan (dipisahkan koma)
 - `-i, --ignore <patterns>`: Pola pengabaian tambahan (dipisahkan koma)
+- `--ignore-content <patterns>`: Skip file content for matched patterns (comma-separated)
 - `--no-gitignore`: Menonaktifkan penggunaan file .gitignore
 - `--no-default-patterns`: Menonaktifkan pola default
 
@@ -74,6 +75,9 @@ repomix --compress
 
 # Memproses file tertentu
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Ignore file contents for matching patterns
+repomix --ignore-content "docs/**,LICENSE"
 
 # Repositori remote dengan branch
 repomix --remote https://github.com/user/repo/tree/main

--- a/website/client/src/id/guide/configuration.md
+++ b/website/client/src/id/guide/configuration.md
@@ -42,6 +42,7 @@ repomix --init --global
 | `output.git.includeLogs`         | Apakah akan menyertakan log git dalam output. Menampilkan riwayat commit dengan tanggal, pesan, dan jalur file            | `false`                |
 | `output.git.includeLogsCount`    | Jumlah commit log git yang akan disertakan dalam output                                                                    | `50`                   |
 | `include`                        | Pola file untuk disertakan menggunakan [pola glob](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)  | `[]`                   |
+| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
 | `ignore.useGitignore`            | Apakah akan menggunakan pola dari file `.gitignore` proyek                                                                  | `true`                 |
 | `ignore.useDefaultPatterns`      | Apakah akan menggunakan pola ignore default (node_modules, .git, dll.)                                                     | `true`                 |
 | `ignore.customPatterns`          | Pola tambahan untuk diabaikan menggunakan [pola glob](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax) | `[]`                   |
@@ -105,6 +106,7 @@ Berikut adalah contoh file konfigurasi lengkap (`repomix.config.json`):
     }
   },
   "include": ["**/*"],
+  "ignoreContent": ["docs/**","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,

--- a/website/client/src/ja/guide/command-line-options.md
+++ b/website/client/src/ja/guide/command-line-options.md
@@ -35,6 +35,7 @@
 ## ファイル選択オプション
 - `--include <patterns>`: 含めるパターンのリスト（カンマ区切り）
 - `-i, --ignore <patterns>`: 追加の除外パターン（カンマ区切り）
+- `--ignore-content <patterns>`: Skip file content for matched patterns (comma-separated)
 - `--no-gitignore`: .gitignoreファイルの使用を無効化
 - `--no-default-patterns`: デフォルトパターンを無効化
 
@@ -79,6 +80,9 @@ repomix --include-diffs --include-logs  # 差分とログの両方を含める
 
 # 特定のファイルを処理
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Ignore file contents for matching patterns
+repomix --ignore-content "docs/**,LICENSE"
 
 # ブランチを指定したリモートリポジトリ
 repomix --remote https://github.com/user/repo/tree/main

--- a/website/client/src/ja/guide/configuration.md
+++ b/website/client/src/ja/guide/configuration.md
@@ -42,6 +42,7 @@ repomix --init --global
 | `output.git.includeLogs`         | 出力にGitログを含めるかどうか。コミット履歴の日時、メッセージ、ファイルパスを表示します                                   | `false`                |
 | `output.git.includeLogsCount`    | 含めるGitログのコミット数。開発パターンを理解するための履歴の深さを制限します                                           | `50`                   |
 | `include`                        | 含めるファイルのパターン（[globパターン](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)を使用）    | `[]`                   |
+| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
 | `ignore.useGitignore`            | プロジェクトの`.gitignore`ファイルのパターンを使用するかどうか                                                             | `true`                 |
 | `ignore.useDefaultPatterns`      | デフォルトの除外パターン（node_modules、.gitなど）を使用するかどうか                                                       | `true`                 |
 | `ignore.customPatterns`          | 追加の除外パターン（[globパターン](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)を使用）          | `[]`                   |
@@ -105,6 +106,7 @@ repomix --init --global
     }
   },
   "include": ["**/*"],
+  "ignoreContent": ["docs/**","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,

--- a/website/client/src/ko/guide/command-line-options.md
+++ b/website/client/src/ko/guide/command-line-options.md
@@ -35,6 +35,7 @@
 ## 파일 선택 옵션
 - `--include <patterns>`: 포함 패턴 목록 (쉼표로 구분)
 - `-i, --ignore <patterns>`: 추가 무시 패턴 (쉼표로 구분)
+- `--ignore-content <patterns>`: Skip file content for matched patterns (comma-separated)
 - `--no-gitignore`: .gitignore 파일 사용 비활성화
 - `--no-default-patterns`: 기본 패턴 비활성화
 
@@ -79,6 +80,9 @@ repomix --include-diffs --include-logs  # 차이점과 로그 모두 포함
 
 # 특정 파일 처리
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Ignore file contents for matching patterns
+repomix --ignore-content "docs/**,LICENSE"
 
 # 브랜치가 있는 원격 저장소
 repomix --remote https://github.com/user/repo/tree/main

--- a/website/client/src/ko/guide/configuration.md
+++ b/website/client/src/ko/guide/configuration.md
@@ -42,6 +42,7 @@ repomix --init --global
 | `output.git.includeLogs`         | 출력에 Git 로그를 포함할지 여부. 커밋 히스토리의 날짜, 메시지, 파일 경로를 표시합니다                                   | `false`                |
 | `output.git.includeLogsCount`    | 포함할 Git 로그 커밋 수. 개발 패턴을 이해하기 위한 히스토리 깊이를 제한합니다                                          | `50`                   |
 | `include`                        | 포함할 파일 패턴([glob 패턴](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax) 사용)                 | `[]`                   |
+| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
 | `ignore.useGitignore`            | 프로젝트의 `.gitignore` 파일의 패턴을 사용할지 여부                                                                        | `true`                 |
 | `ignore.useDefaultPatterns`      | 기본 무시 패턴(node_modules, .git 등)을 사용할지 여부                                                                     | `true`                 |
 | `ignore.customPatterns`          | 추가 무시 패턴([glob 패턴](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax) 사용)                   | `[]`                   |
@@ -105,6 +106,7 @@ repomix --init --global
     }
   },
   "include": ["**/*"],
+  "ignoreContent": ["docs/**","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,

--- a/website/client/src/pt-br/guide/command-line-options.md
+++ b/website/client/src/pt-br/guide/command-line-options.md
@@ -35,6 +35,7 @@
 ## Opções de Seleção de Arquivos
 - `--include <patterns>`: Lista de padrões de inclusão (separados por vírgula)
 - `-i, --ignore <patterns>`: Padrões de ignorar adicionais (separados por vírgula)
+- `--ignore-content <patterns>`: Skip file content for matched patterns (comma-separated)
 - `--no-gitignore`: Desabilitar uso do arquivo .gitignore
 - `--no-default-patterns`: Desabilitar padrões padrão
 
@@ -74,6 +75,9 @@ repomix --compress
 
 # Processar arquivos específicos
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Ignore file contents for matching patterns
+repomix --ignore-content "docs/**,LICENSE"
 
 # Repositório remoto com branch
 repomix --remote https://github.com/user/repo/tree/main

--- a/website/client/src/pt-br/guide/configuration.md
+++ b/website/client/src/pt-br/guide/configuration.md
@@ -42,6 +42,7 @@ repomix --init --global
 | `output.git.includeLogs`         | Indica se deve incluir logs do git na saída. Mostra histórico de commits com datas, mensagens e caminhos de arquivos            | `false`                |
 | `output.git.includeLogsCount`    | Número de commits do log do git para incluir na saída                                                                          | `50`                   |
 | `include`                        | Padrões de arquivos para incluir usando [padrões glob](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax) | `[]`                   |
+| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
 | `ignore.useGitignore`            | Indica se deve usar os padrões do arquivo `.gitignore` do projeto                                                        | `true`                 |
 | `ignore.useDefaultPatterns`      | Indica se deve usar os padrões de ignorar padrão (node_modules, .git, etc.)                                            | `true`                 |
 | `ignore.customPatterns`          | Padrões adicionais para ignorar usando [padrões glob](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax) | `[]`                   |
@@ -105,6 +106,7 @@ Aqui está um exemplo de um arquivo de configuração completo (`repomix.config.
     }
   },
   "include": ["**/*"],
+  "ignoreContent": ["docs/**","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,

--- a/website/client/src/vi/guide/command-line-options.md
+++ b/website/client/src/vi/guide/command-line-options.md
@@ -35,6 +35,7 @@
 ## Tùy chọn Lựa chọn Tệp
 - `--include <patterns>`: Danh sách các mẫu bao gồm (phân tách bằng dấu phẩy)
 - `-i, --ignore <patterns>`: Các mẫu bỏ qua bổ sung (phân tách bằng dấu phẩy)
+- `--ignore-content <patterns>`: Skip file content for matched patterns (comma-separated)
 - `--no-gitignore`: Tắt việc sử dụng tệp .gitignore
 - `--no-default-patterns`: Tắt các mẫu mặc định
 
@@ -74,6 +75,9 @@ repomix --compress
 
 # Xử lý tệp cụ thể
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Ignore file contents for matching patterns
+repomix --ignore-content "docs/**,LICENSE"
 
 # Kho lưu trữ từ xa với nhánh
 repomix --remote https://github.com/user/repo/tree/main

--- a/website/client/src/vi/guide/configuration.md
+++ b/website/client/src/vi/guide/configuration.md
@@ -42,6 +42,7 @@ repomix --init --global
 | `output.git.includeLogs`         | Có nên bao gồm nhật ký git trong đầu ra hay không. Hiển thị lịch sử commit với ngày tháng, thông điệp và đường dẫn tệp    | `false`                |
 | `output.git.includeLogsCount`    | Số lượng commit git logs để bao gồm trong đầu ra                                                                          | `50`                   |
 | `include`                        | Các mẫu file để bao gồm sử dụng [mẫu glob](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)         | `[]`                   |
+| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
 | `ignore.useGitignore`            | Có nên sử dụng các mẫu từ file `.gitignore` của dự án hay không                                                            | `true`                 |
 | `ignore.useDefaultPatterns`      | Có nên sử dụng các mẫu ignore mặc định (node_modules, .git, v.v.) hay không                                               | `true`                 |
 | `ignore.customPatterns`          | Các mẫu bổ sung để ignore sử dụng [mẫu glob](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)       | `[]`                   |
@@ -105,6 +106,7 @@ Bạn có thể bật xác thực schema cho file cấu hình của mình bằng
     }
   },
   "include": ["**/*"],
+  "ignoreContent": ["docs/**","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,

--- a/website/client/src/zh-cn/guide/command-line-options.md
+++ b/website/client/src/zh-cn/guide/command-line-options.md
@@ -35,6 +35,7 @@
 ## 文件选择选项
 - `--include <patterns>`: 包含模式列表（逗号分隔）
 - `-i, --ignore <patterns>`: 附加忽略模式（逗号分隔）
+- `--ignore-content <patterns>`: Skip file content for matched patterns (comma-separated)
 - `--no-gitignore`: 禁用.gitignore文件使用
 - `--no-default-patterns`: 禁用默认模式
 
@@ -79,6 +80,9 @@ repomix --include-diffs --include-logs  # 同时包含差异和日志
 
 # 处理特定文件
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Ignore file contents for matching patterns
+repomix --ignore-content "docs/**,LICENSE"
 
 # 带分支的远程仓库
 repomix --remote https://github.com/user/repo/tree/main

--- a/website/client/src/zh-cn/guide/configuration.md
+++ b/website/client/src/zh-cn/guide/configuration.md
@@ -42,6 +42,7 @@ repomix --init --global
 | `output.git.includeLogs`         | 是否在输出中包含Git日志。显示提交历史的日期、消息和文件路径                                                              | `false`                |
 | `output.git.includeLogsCount`    | 要包含的Git日志提交数量。限制历史深度以了解开发模式                                                                      | `50`                   |
 | `include`                        | 要包含的文件模式（使用[glob模式](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)）                 | `[]`                   |
+| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
 | `ignore.useGitignore`            | 是否使用项目的`.gitignore`文件中的模式                                                                                     | `true`                 |
 | `ignore.useDefaultPatterns`      | 是否使用默认忽略模式（node_modules、.git等）                                                                              | `true`                 |
 | `ignore.customPatterns`          | 额外的忽略模式（使用[glob模式](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)）                   | `[]`                   |
@@ -105,6 +106,7 @@ repomix --init --global
     }
   },
   "include": ["**/*"],
+  "ignoreContent": ["docs/**","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,

--- a/website/client/src/zh-tw/guide/command-line-options.md
+++ b/website/client/src/zh-tw/guide/command-line-options.md
@@ -35,6 +35,7 @@
 ## 檔案選擇選項
 - `--include <patterns>`: 包含模式清單（逗號分隔）
 - `-i, --ignore <patterns>`: 附加忽略模式（逗號分隔）
+- `--ignore-content <patterns>`: Skip file content for matched patterns (comma-separated)
 - `--no-gitignore`: 停用.gitignore檔案使用
 - `--no-default-patterns`: 停用預設模式
 
@@ -74,6 +75,9 @@ repomix --compress
 
 # 處理特定檔案
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Ignore file contents for matching patterns
+repomix --ignore-content "docs/**,LICENSE"
 
 # 帶分支的遠端儲存庫
 repomix --remote https://github.com/user/repo/tree/main

--- a/website/client/src/zh-tw/guide/configuration.md
+++ b/website/client/src/zh-tw/guide/configuration.md
@@ -42,6 +42,7 @@ repomix --init --global
 | `output.git.includeLogs`         | 是否在輸出中包含Git記錄。顯示提交歷史包括日期、訊息和檔案路徑                                                            | `false`                |
 | `output.git.includeLogsCount`    | 在輸出中包含的git記錄提交數量                                                                                        | `50`                   |
 | `include`                        | 要包含的檔案模式（使用[glob模式](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)）                 | `[]`                   |
+| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
 | `ignore.useGitignore`            | 是否使用專案的`.gitignore`檔案中的模式                                                                                     | `true`                 |
 | `ignore.useDefaultPatterns`      | 是否使用預設忽略模式（node_modules、.git等）                                                                              | `true`                 |
 | `ignore.customPatterns`          | 額外的忽略模式（使用[glob模式](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)）                   | `[]`                   |
@@ -105,6 +106,7 @@ repomix --init --global
     }
   },
   "include": ["**/*"],
+  "ignoreContent": ["docs/**","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,


### PR DESCRIPTION
## Summary
- support `ignoreContent` config to skip reading matched files
- add `--ignore-content` CLI flag
- document option and cover with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9d127df208330b0dc8e323820dc13