### PR TITLE
feat: skip file contents using directory paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,7 +963,7 @@ Here's an explanation of the configuration options:
 | `output.git.includeLogs`        | Whether to include git logs in the output (includes commit history with dates, messages, and file paths)                   | `false`                |
 | `output.git.includeLogsCount`   | Number of git log commits to include                                                                                         | `50`                   |
 | `include`                        | Patterns of files to include (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax))  | `[]`                   |
-| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
+| `ignoreContent`                  | Paths or glob patterns of files whose content should be ignored (subdirectories are ignored when a directory path is provided) | `[]`                   |
 | `ignore.useGitignore`            | Whether to use patterns from the project's `.gitignore` file                                                                 | `true`                 |
 | `ignore.useDefaultPatterns`      | Whether to use default ignore patterns                                                                                       | `true`                 |
 | `ignore.customPatterns`          | Additional patterns to ignore (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
@@ -1009,7 +1009,7 @@ Example configuration:
     }
   },
   "include": ["**/*"],
-  "ignoreContent": ["docs/**","LICENSE"],
+  "ignoreContent": ["docs","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,

--- a/tests/core/file/fileCollect.test.ts
+++ b/tests/core/file/fileCollect.test.ts
@@ -103,6 +103,27 @@ describe('fileCollect', () => {
     expect(fs.readFile).toHaveBeenCalledTimes(1);
   });
 
+  it('should skip file content when ignoreContent contains directory path', async () => {
+    const mockFilePaths = ['docs/readme.md', 'src/index.ts'];
+    const mockRootDir = '/root';
+    const mockConfig = createMockConfig({ ignoreContent: ['docs'] });
+
+    vi.mocked(isBinary).mockReturnValue(false);
+    vi.mocked(fs.readFile).mockResolvedValue(Buffer.from('file content'));
+    vi.mocked(jschardet.detect).mockReturnValue({ encoding: 'utf-8', confidence: 0.99 });
+    vi.mocked(iconv.decode).mockReturnValue('decoded content');
+
+    const result = await collectFiles(mockFilePaths, mockRootDir, mockConfig, () => {}, {
+      initTaskRunner: mockInitTaskRunner,
+    });
+
+    expect(result).toEqual({
+      rawFiles: [{ path: 'docs/readme.md' }, { path: 'src/index.ts', content: 'decoded content' }],
+      skippedFiles: [],
+    });
+    expect(fs.readFile).toHaveBeenCalledTimes(1);
+  });
+
   it('should skip binary files', async () => {
     const mockFilePaths = ['binary.bin', 'text.txt'];
     const mockRootDir = '/root';

--- a/website/client/src/en/guide/command-line-options.md
+++ b/website/client/src/en/guide/command-line-options.md
@@ -35,7 +35,7 @@
 ## File Selection Options
 - `--include <patterns>`: List of include patterns (comma-separated)
 - `-i, --ignore <patterns>`: Additional ignore patterns (comma-separated)
-- `--ignore-content <patterns>`: Skip file content for matched patterns (comma-separated)
+- `--ignore-content <paths>`: Skip file content for matched paths or glob patterns (comma-separated)
 - `--no-gitignore`: Disable .gitignore file usage
 - `--no-default-patterns`: Disable default patterns
 
@@ -74,8 +74,8 @@ repomix --compress
 # Process specific files
 repomix --include "src/**/*.ts" --ignore "**/*.test.ts"
 
-# Ignore file contents for matching patterns
-repomix --ignore-content "docs/**,LICENSE"
+# Ignore file contents for matching paths
+repomix --ignore-content "docs,LICENSE"
 
 # Remote repository with branch
 repomix --remote https://github.com/user/repo/tree/main

--- a/website/client/src/en/guide/configuration.md
+++ b/website/client/src/en/guide/configuration.md
@@ -42,7 +42,7 @@ repomix --init --global
 | `output.git.includeLogs`         | Whether to include git logs in the output. Shows commit history with dates, messages, and file paths                        | `false`                |
 | `output.git.includeLogsCount`    | Number of git log commits to include in the output                                                                          | `50`                   |
 | `include`                        | Patterns of files to include using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)    | `[]`                   |
-| `ignoreContent`                  | Patterns of files whose content should be ignored (using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)) | `[]`                   |
+| `ignoreContent`                  | Paths or glob patterns of files whose content should be ignored (subdirectories are ignored when a directory path is provided) | `[]`                   |
 | `ignore.useGitignore`            | Whether to use patterns from the project's `.gitignore` file                                                                 | `true`                 |
 | `ignore.useDefaultPatterns`      | Whether to use default ignore patterns (node_modules, .git, etc.)                                                           | `true`                 |
 | `ignore.customPatterns`          | Additional patterns to ignore using [glob patterns](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax)   | `[]`                   |
@@ -106,7 +106,7 @@ Here's an example of a complete configuration file (`repomix.config.json`):
     }
   },
   "include": ["**/*"],
-  "ignoreContent": ["docs/**","LICENSE"],
+  "ignoreContent": ["docs","LICENSE"],
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,


### PR DESCRIPTION
## Summary
- allow `ignoreContent` to accept plain directory paths
- document path-based `--ignore-content` usage
- test skipping content for specified directories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd6e1ee3a08330b4e188d2d754ac1e